### PR TITLE
Separator improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Build Status](https://travis-ci.org/achingbrain/output-buffer.svg)](https://travis-ci.org/achingbrain/output-buffer) [![Dependency Status](https://david-dm.org/achingbrain/output-buffer.svg)](https://david-dm.org/achingbrain/output-buffer) [![Coverage Status](https://img.shields.io/coveralls/achingbrain/output-buffer/master.svg)](https://coveralls.io/r/achingbrain/output-buffer)
 
 
-Buffers your output.  When newlines are detected, it calls the function passed to the constructor with the line of data.
-
+Buffers your output.  When line separators are detected, it calls the function passed to the constructor with the line of data.
 ## Usage
 
 ```javascript
@@ -17,4 +16,16 @@ buffer.append('\n')  // prints 'foobar'
 buffer.append('foo')
 buffer.append('ba\nr') // prints fooba
 buffer.flush() // prints 'r'
+```
+
+The default line separator handles CR, LF and CRLF, but a custom separator (string or regex) can be supplied as an optional second argument to the constructor e.g.:
+
+```javascript
+var buffer = new OutputBuffer(console.info, '\r\n')
+```
+
+or:
+
+```javascript
+var buffer = new OutputBuffer(console.info, /\r|\n/)
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Buffers your output.  When newlines are detected, it calls the function passed t
 ## Usage
 
 ```javascript
-var OutputBuffer = require('outputbuffer')
+var OutputBuffer = require('output-buffer')
 
 var buffer = new OutputBuffer(console.info)
 buffer.append('foo')

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var OutputBuffer = require('../lib/OutputBuffer');
+var assert       = require('assert');
+var Benchmark    = require('benchmark');
+var benchmarks   = require('beautify-benchmark');
+
+var stringSplitBuffer = new OutputBuffer(null, '\n');
+var regexSplitBuffer  = new OutputBuffer();
+var oldBuffer         = new OutputBuffer();
+var suite             = new Benchmark.Suite();
+
+var LINE  = 'The quick brown fox jumps over the lazy dog.';
+var LINES = [ LINE + LINE, LINE, LINE, LINE, LINE + LINE ];
+
+oldBuffer.append = function (data) {
+    this._buffer += data
+    var index = this._buffer.indexOf('\n')
+
+    while (index != -1) {
+        var sub = this._buffer.substring(0, index)
+
+        this._out(sub)
+
+        this._buffer = this._buffer.substring(index + 1)
+        index = this._buffer.indexOf('\n')
+    }
+};
+
+function addTest (name, buffer) {
+    suite.add(name, function () {
+        var lines = [];
+
+        buffer._out = function (line) {
+            lines.push(line);
+        };
+
+        buffer.append(LINE);
+        buffer.append(LINE);
+        buffer.append('\n' + LINE);
+        buffer.append('\n' + LINE + '\n');
+        buffer.append(LINE + '\n');
+        buffer.append(LINE);
+        buffer.append(LINE);
+        buffer.flush();
+
+        assert.deepEqual(lines, LINES);
+    });
+}
+
+addTest('string-split buffer', stringSplitBuffer);
+addTest('regex-split buffer', regexSplitBuffer);
+addTest('old buffer', oldBuffer);
+
+suite.on('cycle', function (event) {
+    benchmarks.add(event.target);
+});
+
+suite.on('start', function () {
+    console.log('Starting...\n');
+});
+
+suite.on('complete', function () {
+    benchmarks.log();
+});
+
+suite.run({ async: false });

--- a/lib/OutputBuffer.js
+++ b/lib/OutputBuffer.js
@@ -1,21 +1,53 @@
 
-var OutputBuffer = function(out) {
-  this._out = out
-  this._buffer = ''
-}
+function stringSplitAppend(data) {
+  var sep, index, sub
 
-OutputBuffer.prototype.append = function(data) {
+  sep = this._sep
   this._buffer += data
-  var index = this._buffer.indexOf('\n')
+  index = this._buffer.indexOf(sep)
 
-  while(index != -1) {
-    var sub = this._buffer.substring(0, index)
+  while (index != -1) {
+    sub = this._buffer.substring(0, index)
 
     this._out(sub)
 
     this._buffer = this._buffer.substring(index + 1)
-    index = this._buffer.indexOf('\n')
+    index = this._buffer.indexOf(sep)
   }
+}
+
+function regexSplitAppend(data) {
+  var lines = data.split(this._sep)
+  var len = lines.length
+  var last, i
+
+  switch (len) {
+    case 1: // no line terminators
+      this._buffer += lines[0]
+      break
+    case 2: // one line terminator
+      this._out(this._buffer + lines[0])
+      this._buffer = lines[1]
+      break
+    default: // more than one line terminator
+      last = len - 1
+      this._out(this._buffer + lines[0])
+      for (i = 1; i < last; ++i) {
+        this._out(lines[i])
+      }
+      this._buffer = lines[last]
+  }
+}
+
+var OutputBuffer = function(out, sep) {
+  this._out = out
+  this._sep = sep || /\r\n|\r|\n/
+  this._buffer = ''
+  this._append = ({}.toString.call(this._sep) === '[object RegExp]') ? regexSplitAppend : stringSplitAppend
+}
+
+OutputBuffer.prototype.append = function(data) {
+  if(data != null) this._append(data)
 }
 
 OutputBuffer.prototype.flush = function() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "istanbul cover _mocha",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "benchmark": "mocha benchmark/benchmark.js"
   },
   "repository": {
     "type": "git",
@@ -22,10 +23,12 @@
   },
   "homepage": "https://github.com/achingbrain/output-buffer",
   "devDependencies": {
+    "beautify-benchmark": "^0.2.4",
+    "benchmark": "^1.0.0",
+    "chai": "^1.0",
     "coveralls": "^2.8",
     "istanbul": "^0.3.0",
-    "mocha": "^2.0",
-    "chai": "^1.0",
+    "mocha": "^2.1.0",
     "sinon": "^1.8",
     "testsuite": "^1.0"
   }

--- a/test/lib/OutputBufferTest.js
+++ b/test/lib/OutputBufferTest.js
@@ -20,4 +20,252 @@ describe('OutputBuffer', function() {
     expect(output.getCall(0).args[0]).to.equal('foofoofo')
     expect(output.getCall(1).args[0]).to.equal('ofoo')
   })
+
+  it('should not emit an unterminated line without flush', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\nbar\nbaz')
+
+    expect(output.callCount).to.equal(2)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+  })
+
+  it('should emit an unterminated line with flush', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\nbar\nbaz')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should flush a trailing zero', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\nbar\nbaz\n0')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(4)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+    expect(output.getCall(3).args[0]).to.equal('0')
+  })
+
+  it('should split lines on CR', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\rbar\rbaz')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should split lines on LF', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\nbar\nbaz')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should split lines on CRLF', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\r\nbar\r\nbaz')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should split lines on any combination of CR, LF and CRLF', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\rbar\nbaz\r\nquux')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(4)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+    expect(output.getCall(3).args[0]).to.equal('quux')
+  })
+
+  it('should handle a leading line terminator', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('\rfoo\nbar\r\nbaz')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(4)
+    expect(output.getCall(0).args[0]).to.equal('')
+    expect(output.getCall(1).args[0]).to.equal('foo')
+    expect(output.getCall(2).args[0]).to.equal('bar')
+    expect(output.getCall(3).args[0]).to.equal('baz')
+  })
+
+  it('should handle a trailing line terminator', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\rbar\nbaz\r\n')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should handle a leading and trailing line terminator', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('\rfoo\nbar\r\n')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('')
+    expect(output.getCall(1).args[0]).to.equal('foo')
+    expect(output.getCall(2).args[0]).to.equal('bar')
+  })
+
+  it('should treat LFCR as two line separators', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\n\rbar')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('')
+    expect(output.getCall(2).args[0]).to.equal('bar')
+  })
+
+  it('should treat LFCRLF as two line separators', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\n\r\nbar')
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('')
+    expect(output.getCall(2).args[0]).to.equal('bar')
+  })
+
+  it('should handle empty strings', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo\n');
+    buffer.append('');
+    buffer.append('\nbar');
+    buffer.append('');
+    buffer.append('');
+    buffer.append('\nbaz\n');
+    buffer.append('');
+    buffer.append('');
+    buffer.append('');
+    buffer.append('quux');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(5)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('')
+    expect(output.getCall(2).args[0]).to.equal('bar')
+    expect(output.getCall(3).args[0]).to.equal('baz')
+    expect(output.getCall(4).args[0]).to.equal('quux')
+  })
+
+  it('should ignore null values', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo');
+    buffer.append(null);
+    buffer.append('bar\nbaz');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(2)
+    expect(output.getCall(0).args[0]).to.equal('foobar')
+    expect(output.getCall(1).args[0]).to.equal('baz')
+  })
+
+  it('should ignore undefined values', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output)
+    buffer.append('foo');
+    buffer.append(undefined);
+    buffer.append('bar\nbaz');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(2)
+    expect(output.getCall(0).args[0]).to.equal('foobar')
+    expect(output.getCall(1).args[0]).to.equal('baz')
+  })
+
+  it('should allow the line separator to be supplied as a string', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output, '\n')
+    buffer.append('foo\r\nbar\r\nbaz');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo\r')
+    expect(output.getCall(1).args[0]).to.equal('bar\r')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should allow the line separator to be supplied as a regex', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output, /\n/)
+    buffer.append('foo\r\nbar\r\nbaz');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo\r')
+    expect(output.getCall(1).args[0]).to.equal('bar\r')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
+
+  it('should use the default line separator if the separator is falsey', function() {
+    var output = sinon.stub()
+
+    var buffer = new OutputBuffer(output, '')
+    buffer.append('foo\r\nbar\r\nbaz');
+    buffer.flush()
+
+    expect(output.callCount).to.equal(3)
+    expect(output.getCall(0).args[0]).to.equal('foo')
+    expect(output.getCall(1).args[0]).to.equal('bar')
+    expect(output.getCall(2).args[0]).to.equal('baz')
+  })
 })


### PR DESCRIPTION
- separator improvements
  - add support for [Windows/Mac OS 9 &c. line endings](https://en.wikipedia.org/wiki/Newline#Representations)
  - allow the line separator to be specified
  - use the (slightly faster) old append method if the line separator is a string
- ignore null/undefined
- comprehensive tests
- add benchmark
- README.md: update package name: `outputbuffer` -> `output-buffer`
